### PR TITLE
Fxies unicode issues trying to do radd or add

### DIFF
--- a/bottle_utils/html.py
+++ b/bottle_utils/html.py
@@ -130,10 +130,10 @@ class QueryDict(MultiDict):
         return '?' + str(self)
 
     def __radd__(self, other):
-        return other + self.to_qs()
+        return other + str(self.to_qs())
 
     def __add__(self, other):
-        return self.to_qs() + other
+        return str(self.to_qs()) + other
 
     def __str__(self):
         return '&'.join(['{}={}'.format(urlquote(k), urlquote(v))


### PR DESCRIPTION
When doing radd or add with query strings, mixed unicode and non-unicode
strings causes issues. This patch fixed unicode issues.

Signed-off-by: Branko Vukelic <branko@outernet.is>