### PR TITLE
Fix a typo

### DIFF
--- a/bottle_utils/csrf.py
+++ b/bottle_utils/csrf.py
@@ -81,7 +81,7 @@ def csrf_token(func):
     hidden field must have a name ``_csrf_token``::
 
         <form method="POST">
-            <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+            <input type="hidden" name="_csrf_token" value="{{ token }}">
             ....
         </form>
     """
@@ -162,4 +162,3 @@ def csrf_tag():
     except AttributeError:
         pass
     return HIDDEN(token_name, token)
-


### PR DESCRIPTION
According to `return dict(token=request.csrf_token)`, the function we should use in template is `token` not `csrf_token`