### PR TITLE
Feature/ordered fields

### DIFF
--- a/bottle_utils/form/fields.py
+++ b/bottle_utils/form/fields.py
@@ -30,7 +30,19 @@ class ErrorMixin(object):
         return message
 
 
-class DormantField(object):
+class Ordered(object):
+    #: Counter attribute holding the number of fields found on a form, used
+    #: to assign indexes to individual fields, so their order can be kept
+    _counter = 0
+
+    def __init__(self):
+        #: Assign index to the instantiated field and increment the shared
+        #: counter, so the next field will get a higher index
+        self._order = self._counter
+        Ordered._counter += 1
+
+
+class DormantField(Ordered):
     """
     Proxy for unbound fields. This class holds the the field constructor
     arguments until the data can be bound to it.
@@ -39,6 +51,7 @@ class DormantField(object):
     """
 
     def __init__(self, field_cls, args, kwargs):
+        super(DormantField, self).__init__()  # needed to apply ordering
         self.field_cls = field_cls
         self.args = args
         self.kwargs = kwargs
@@ -47,7 +60,7 @@ class DormantField(object):
         return self.field_cls(name=name, *self.args, **self.kwargs)
 
 
-class Field(ErrorMixin):
+class Field(Ordered, ErrorMixin):
     """
     Form field base class. This class provides the base functionality for all
     form fields.
@@ -95,6 +108,8 @@ class Field(ErrorMixin):
 
     def __init__(self, label=None, validators=None, value=None, name=None,
                  messages={}, **options):
+        super(Field, self).__init__()  # needed to apply ordering
+
         #: Field name
         self.name = name
 

--- a/bottle_utils/form/fields.py
+++ b/bottle_utils/form/fields.py
@@ -1,4 +1,3 @@
-from bottle_utils import html
 from bottle_utils.common import basestring, unicode
 
 try:
@@ -8,6 +7,7 @@ except ImportError:
 
 from .exceptions import ValidationError
 from .validators import DateValidator
+
 
 class ErrorMixin(object):
     """
@@ -57,8 +57,8 @@ class Field(ErrorMixin):
     The ``validators`` argument is used to specify the validators that will be
     used on the field data.
 
-    If any data should be bound to a field, the ``value`` argument can be used to
-    specify it. Value can be a callable, in which case it is called and its
+    If any data should be bound to a field, the ``value`` argument can be used
+    to specify it. Value can be a callable, in which case it is called and its
     return value used as ``value``.
 
     The ``name`` argument is used to specify the field name.

--- a/bottle_utils/form/forms.py
+++ b/bottle_utils/form/forms.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 try:
     from bottle_utils.i18n import lazy_gettext as _
 except ImportError:
@@ -103,8 +105,9 @@ class Form(ErrorMixin):
         types = (Field, DormantField)
         is_form_field = lambda name: isinstance(getattr(self, name), types)
         ignored_attrs = ['fields', 'field_messages', 'field_errors']
-        return dict((name, getattr(self, name)) for name in dir(self)
-                    if name not in ignored_attrs and is_form_field(name))
+        pairs = [(name, getattr(self, name)) for name in dir(self)
+                 if name not in ignored_attrs and is_form_field(name)]
+        return OrderedDict(sorted(pairs, key=lambda x: x[1]._order))
 
     def _add_error(self, field, error):
         # if the error is from one of the processors, bind it to the field too

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -20,9 +20,6 @@ except ImportError:
 import pytest
 
 import bottle_utils.form as mod
-from bottle_utils.lazy import Lazy
-
-MOD = mod.__name__
 
 
 class TestValidator(object):
@@ -56,6 +53,14 @@ class TestValidator(object):
 
 
 class TestField(object):
+
+    def test_order(self):
+        field1 = mod.Field()
+        field2 = mod.Field()
+        field3 = mod.Field()
+        assert field1._order == 0
+        assert field2._order == 1
+        assert field3._order == 2
 
     def test_bind(self):
         class CustomField(mod.Field):
@@ -246,6 +251,12 @@ class TestForm(object):
     def test_fields(self, form_cls):
         form = form_cls({})
         assert form.fields == {'field1': form.field1, 'field2': form.field2}
+
+    def test_fields_order(self, form_cls):
+        form = form_cls()
+        fields = list(form.fields.items())
+        assert fields[0][1].name == 'field1'
+        assert fields[1][1].name == 'field2'
 
     def test_is_valid_success(self, form_cls):
         mocked_field = mock.Mock()


### PR DESCRIPTION
This PR makes the `Form.fields` property to returns the form fields in the same order as they are found in the form class definition.