### PR TITLE
add full_quoted_string function

### DIFF
--- a/bottle_utils/html.py
+++ b/bottle_utils/html.py
@@ -21,6 +21,7 @@ SIZES = 'KMGTP'
 FERR_CLS = 'form-errors'
 FERR_ONE_CLS = 'form-error'
 ERR_CLS = 'field-error'
+HTTP_PORTS = '80 993'.split()
 
 
 urlquote = lambda value: quote(to_bytes(value))
@@ -689,6 +690,22 @@ def quote_dict(mapping):
 def quoted_url(route, **params):
     """Return matching URL with it's query parameters quoted."""
     return request.app.get_url(route, **quote_dict(params))
+
+
+def full_quoted_url(route, **params):
+    """
+    Return matching URL with its query parameters quoted and a full domain
+    prefix, including port if not on typical http ports.
+    """
+
+    domain = request.urlparts.netloc
+    if request.urlparts.port in HTTP_PORTS:
+        port = ''
+    else:
+        port = ':' + str(request.urlparts.port)
+    suffix = quoted_url(route, **params)
+
+    return '//{d}{p}{s}'.format(d=domain, p=port, s=suffix)
 
 
 def to_qs(mapping):

--- a/bottle_utils/html.py
+++ b/bottle_utils/html.py
@@ -692,9 +692,13 @@ def quoted_url(route, **params):
     return request.app.get_url(route, **quote_dict(params))
 
 
-def full_domain(with_scheme=False):
+def full_url(path='', with_scheme=False):
     """
-    Return a full domain prefix, including port if not on typical http ports.
+    Return full URL with an optional scheme, the domain, the port if it's not a
+    typical http port, and an optional path.
+
+    Note that the path is added to the URL verbatim, therefore it must start
+    with a forward slash and must be a string.
     """
 
     try:
@@ -707,7 +711,7 @@ def full_domain(with_scheme=False):
         port = ':' + str(request.urlparts.port)
     scheme = str(request.urlparts.scheme + "://") if with_scheme else '//'
 
-    return '{s}{d}{p}'.format(s=scheme, d=domain, p=port)
+    return ''.join([scheme, domain, port, path])
 
 
 def to_qs(mapping):

--- a/bottle_utils/html.py
+++ b/bottle_utils/html.py
@@ -21,7 +21,7 @@ SIZES = 'KMGTP'
 FERR_CLS = 'form-errors'
 FERR_ONE_CLS = 'form-error'
 ERR_CLS = 'field-error'
-HTTP_PORTS = '80 443'.split()
+HTTP_PORTS = ('80', '443')
 
 
 urlquote = lambda value: quote(to_bytes(value))

--- a/bottle_utils/html.py
+++ b/bottle_utils/html.py
@@ -698,7 +698,10 @@ def full_quoted_url(route, **params):
     prefix, including port if not on typical http ports.
     """
 
-    domain = request.urlparts.netloc
+    try:
+        domain, _ = request.urlparts.netloc.split(':')
+    except ValueError:
+        domain = request.urlparts.netloc
     if request.urlparts.port in HTTP_PORTS:
         port = ''
     else:

--- a/bottle_utils/html.py
+++ b/bottle_utils/html.py
@@ -692,10 +692,9 @@ def quoted_url(route, **params):
     return request.app.get_url(route, **quote_dict(params))
 
 
-def full_quoted_url(route, with_scheme=False, **params):
+def full_domain(with_scheme=False):
     """
-    Return matching URL with its query parameters quoted and a full domain
-    prefix, including port if not on typical http ports.
+    Return a full domain prefix, including port if not on typical http ports.
     """
 
     try:
@@ -706,10 +705,9 @@ def full_quoted_url(route, with_scheme=False, **params):
         port = ''
     else:
         port = ':' + str(request.urlparts.port)
-    suffix = quoted_url(route, **params)
     scheme = str(request.urlparts.scheme + "://") if with_scheme else '//'
 
-    return '{c}{d}{p}{s}'.format(c=scheme, d=domain, p=port, s=suffix)
+    return '{s}{d}{p}'.format(s=scheme, d=domain, p=port)
 
 
 def to_qs(mapping):

--- a/bottle_utils/html.py
+++ b/bottle_utils/html.py
@@ -698,10 +698,10 @@ def full_domain(with_scheme=False):
     """
 
     try:
-        domain, _ = request.urlparts.netloc.split(':')
+        domain, _ = request.urlparts.netloc.rsplit(':')
     except ValueError:
         domain = request.urlparts.netloc
-    if request.urlparts.port in HTTP_PORTS:
+    if request.urlparts.port in HTTP_PORTS or request.urlparts.port is None:
         port = ''
     else:
         port = ':' + str(request.urlparts.port)

--- a/bottle_utils/html.py
+++ b/bottle_utils/html.py
@@ -21,7 +21,7 @@ SIZES = 'KMGTP'
 FERR_CLS = 'form-errors'
 FERR_ONE_CLS = 'form-error'
 ERR_CLS = 'field-error'
-HTTP_PORTS = '80 993'.split()
+HTTP_PORTS = '80 443'.split()
 
 
 urlquote = lambda value: quote(to_bytes(value))

--- a/bottle_utils/html.py
+++ b/bottle_utils/html.py
@@ -707,7 +707,7 @@ def full_quoted_url(route, with_scheme=False, **params):
     else:
         port = ':' + str(request.urlparts.port)
     suffix = quoted_url(route, **params)
-    scheme = request.urlparts.scheme if with_scheme else '//'
+    scheme = str(request.urlparts.scheme + "://") if with_scheme else '//'
 
     return '{c}{d}{p}{s}'.format(c=scheme, d=domain, p=port, s=suffix)
 

--- a/bottle_utils/html.py
+++ b/bottle_utils/html.py
@@ -692,7 +692,7 @@ def quoted_url(route, **params):
     return request.app.get_url(route, **quote_dict(params))
 
 
-def full_quoted_url(route, **params):
+def full_quoted_url(route, with_scheme=False, **params):
     """
     Return matching URL with its query parameters quoted and a full domain
     prefix, including port if not on typical http ports.
@@ -707,8 +707,9 @@ def full_quoted_url(route, **params):
     else:
         port = ':' + str(request.urlparts.port)
     suffix = quoted_url(route, **params)
+    scheme = request.urlparts.scheme if with_scheme else '//'
 
-    return '//{d}{p}{s}'.format(d=domain, p=port, s=suffix)
+    return '{c}{d}{p}{s}'.format(c=scheme, d=domain, p=port, s=suffix)
 
 
 def to_qs(mapping):

--- a/docs/source/html.rst
+++ b/docs/source/html.rst
@@ -61,3 +61,4 @@ URL handling
 .. autofunction:: urlunquote
 .. autofunction:: quote_dict
 .. autofunction:: quoted_url
+.. autofunction:: full_quoted_url

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -493,6 +493,8 @@ def test_del_qparam_default(request):
     ['https://outernet.is:1234/', '//outernet.is:1234/?query', False],
     ['https://outernet.is:80/', 'https://outernet.is/?query', True],
     ['http://outernet.is:80/', 'http://outernet.is/?query', True],
+    ['http://outernet.is/', 'http://outernet.is/?query', True],
+    ['https://outernet.is/', '//outernet.is/?query', False],
 ))
 @mock.Mock(MOD + 'request.urlparts')
 @mock.patch(MOD + 'quoted_url', return_value='/?query')

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -488,18 +488,19 @@ def test_del_qparam_default(request):
 
 
 @pytest.mark.parametrize('parts expected with_scheme'.split, (
-    ['https://outernet.is:80/', '//outernet.is/?query', False],
-    ['https://outernet.is:443/', '//outernet.is/?query', False],
-    ['https://outernet.is:1234/', '//outernet.is:1234/?query', False],
-    ['https://outernet.is:80/', 'https://outernet.is/?query', True],
-    ['http://outernet.is:80/', 'http://outernet.is/?query', True],
-    ['http://outernet.is/', 'http://outernet.is/?query', True],
-    ['https://outernet.is/', '//outernet.is/?query', False],
+    ['https://outernet.is:80/', '//outernet.is/', False],
+    ['https://outernet.is:443/', '//outernet.is/', False],
+    ['https://outernet.is:1234/', '//outernet.is:1234/', False],
+    ['https://outernet.is:80/', 'https://outernet.is/', True],
+    ['http://outernet.is:80/', 'http://outernet.is/', True],
+    ['http://outernet.is/', 'http://outernet.is/', True],
+    ['http://outernet.is/', '//outernet.is/', False],
+    ['https://outernet.is/', 'https://outernet.is/', True],
+    ['https://outernet.is/', '//outernet.is/', False],
 ))
 @mock.Mock(MOD + 'request.urlparts')
-@mock.patch(MOD + 'quoted_url', return_value='/?query')
-def test_full_quoted_url(parts, expected, with_scheme, request, quoted_url):
+def test_full_domain(parts, expected, with_scheme, request):
     expected = '//outernet.is/?query'
     request.urlparts = urlparse.urlsplit('https://outernet.is:80/')
-    ret = mod.full_quoted_url('test', with_scheme=False)
+    ret = mod.full_quoted_url(with_scheme=with_scheme)
     assert ret == expected


### PR DESCRIPTION
Returns a string with the format ``<domain>:<port>/<query>`` based on the quoted_url function.

This function was added to repair the mixed content issue with broadcast-portal. 