### PR TITLE
Fix value sent for parsing to be the one returned from preprocessing

### DIFF
--- a/bottle_utils/form/fields.py
+++ b/bottle_utils/form/fields.py
@@ -152,9 +152,10 @@ class Field(ErrorMixin):
         argument.
         """
         try:
-            self.processed_value = self.parse(self.value)
+            self.processed_value = self.parse(self.processed_value)
         except ValueError as exc:
-            self._error = ValidationError('generic', {'value': self.value})
+            self._error = ValidationError('generic',
+                                          {'value': self.processed_value})
             return False
 
         for validate in self.validators:


### PR DESCRIPTION
The value returned by the preprocessors (either untouched on changed) is
assigned to the processed_value, thus previously parsing only value
completely ignored any action performed by a preprocessor.